### PR TITLE
Run coveralls on py27 and py26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
     - ./node_modules/.bin/grunt --verbose
 
 after_success:
-    - if [[ $TOX_ENV = "py27" ]]; then travis_retry pip install coveralls; coveralls; fi
+    - travis_retry pip install coveralls; coveralls;


### PR DESCRIPTION
This is to ensure that coveralls status reports to github don't report as "pending" because they don't run for one of the jobs.
